### PR TITLE
schemdraw 0.15

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,53 @@
 {% set name = "schemdraw" %}
-{% set version = "0.16" %}
+{% set version = "0.15" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/schemdraw-{{ version }}.tar.gz
-  sha256: 908689bd4cfa2c19de2b4c94908ed98f3bd6d114ec39bd79349e71a6ce98128f
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 9a59a43b12fc168cc4c681017f4647f01376c9b5abf1e814ae61b7cde208f070
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
   number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - pip
-    - python >=3.7
+    - python
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-    - typing-extensions
+    - python
+    - typing-extensions  # [py<38]
 
 test:
   imports:
     - schemdraw
-  commands:
-    - pip check
+    - schemdraw.elements
+    - schemdraw.logic
+    - schemdraw.dsp
+    - schemdraw.flow
+    - schemdraw.backends
+    - schemdraw.parsing
   requires:
     - pip
+    # for schemdraw.parsing
+    - pyparsing
+  commands:
+    - pip check
 
 about:
   home: https://schemdraw.readthedocs.io/
-  summary: Electrical circuit schematic drawing
   dev_url: https://bitbucket.org/cdelker/schemdraw
+  doc_url: https://bitbucket.org/cdelker/schemdraw
+  summary: Electrical circuit schematic drawing
+  description: Electrical circuit schematic drawing
   license: MIT
+  license_family: MIT
   license_file: LICENSE.txt
 
 extra:


### PR DESCRIPTION
Changelog: https://bitbucket.org/cdelker/schemdraw/src/0.15/CHANGES.txt
License: https://bitbucket.org/cdelker/schemdraw/src/0.15/LICENSE.txt
Requirements: https://bitbucket.org/cdelker/schemdraw/src/0.15/setup.py

Actions:
1. Remove `noarch python`
2. Add flags `--no-deps --no-build-isolation` to `script`
3. Add missing `setuptools` and `wheel` to `host`
4. Fix `python` in `host` and `run`
5. Add more `test/imports`
6. Add `pyparsing` to `test/requires` for `schemdraw.parsing`
7. Add `doc_url`
8. Add `description` 
9. Add `license_family`

Notes:
- `pycaret 3.0.2` requires `schemdraw 0.15`, see https://github.com/pycaret/pycaret/blob/fdc3f7d22a4117577340be6d8fe2db2a889e9d82/requirements.txt#L33. Trying to follow the upstream